### PR TITLE
23 drawer closed

### DIFF
--- a/app/src/main/java/uk/ac/lancs/aurorawatch/activity/MainActivity.java
+++ b/app/src/main/java/uk/ac/lancs/aurorawatch/activity/MainActivity.java
@@ -1,17 +1,12 @@
 package uk.ac.lancs.aurorawatch.activity;
 
-import android.app.Activity;
-import android.support.v7.app.ActionBarActivity;
-import android.support.v7.app.ActionBar;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
 import android.os.Bundle;
-import android.view.LayoutInflater;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
-import android.support.v4.widget.DrawerLayout;
 
 import uk.ac.lancs.aurorawatch.R;
 import uk.ac.lancs.aurorawatch.fragment.AboutFragment;

--- a/app/src/main/java/uk/ac/lancs/aurorawatch/fragment/NavigationDrawerFragment.java
+++ b/app/src/main/java/uk/ac/lancs/aurorawatch/fragment/NavigationDrawerFragment.java
@@ -70,7 +70,7 @@ public class NavigationDrawerFragment extends Fragment {
         // Read in the flag indicating whether or not the user has demonstrated awareness of the
         // drawer. See PREF_USER_LEARNED_DRAWER for details.
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        mUserLearnedDrawer = sp.getBoolean(PREF_USER_LEARNED_DRAWER, false);
+        mUserLearnedDrawer = sp.getBoolean(PREF_USER_LEARNED_DRAWER, true);
 
         if (savedInstanceState != null) {
             mCurrentSelectedPosition = savedInstanceState.getInt(STATE_SELECTED_POSITION);


### PR DESCRIPTION
In `NavigationDrawerFragment`, changed the default value of `mUserLearnedDrawer` to `true` if not set in `SharedPreferences`. See http://stackoverflow.com/questions/25039147/close-navigation-drawer-on-application-start.

Also tidied up some unused imports in `MainActivity`.

@cdomville if you're still about, can you sanity check please?
