### PR TITLE
49 fix alert signup

### DIFF
--- a/app/src/main/java/org/aurorawatchdevs/aurorawatch/activity/SettingsActivity.java
+++ b/app/src/main/java/org/aurorawatchdevs/aurorawatch/activity/SettingsActivity.java
@@ -90,10 +90,11 @@ public class SettingsActivity extends ActionBarActivity {
     public void saveAlertLevel() {
         try {
             //Post alert setting to the cloud...
-            if (!SaveAlertSetting(alertLevel)) {
+            if (!SaveAlertSettingToCloud(alertLevel)) {
                 //if that failed, switch back
                 alertLevel = lastAlertLevel;
             } else {
+                //Saving to the cloud worked, so save locally on the device too.
                 SharedPreferences settings = getSharedPreferences(appName, 0);
                 SharedPreferences.Editor editor = settings.edit();
                 editor.putInt("alertLevel", alertLevel.ordinal());
@@ -172,15 +173,15 @@ public class SettingsActivity extends ActionBarActivity {
         }
     }
 
-    private boolean SaveAlertSetting(final AlertLevel alertLevel) {
-
-        if (!checkUserAccount())
-            return false;
+    private boolean SaveAlertSettingToCloud(final AlertLevel alertLevel) {
 
         if (!isDeviceOnline()) {
             Toast.makeText(this, getResources().getString(R.string.not_online), Toast.LENGTH_SHORT).show();
             return false;
         }
+
+        if (!checkUserAccount())
+            return false;
 
         if (checkPlayServices()) {
             gcm = GoogleCloudMessaging.getInstance(this);
@@ -288,6 +289,7 @@ public class SettingsActivity extends ActionBarActivity {
                     accountName = data.getStringExtra(
                             AccountManager.KEY_ACCOUNT_NAME);
                     AccountUtils.setAccountName(this, accountName);
+
                 } else if (resultCode == RESULT_CANCELED) {
                     Toast.makeText(this, "This application requires a Google account.",
                             Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/org/aurorawatchdevs/aurorawatch/activity/SettingsActivity.java
+++ b/app/src/main/java/org/aurorawatchdevs/aurorawatch/activity/SettingsActivity.java
@@ -102,6 +102,7 @@ public class SettingsActivity extends ActionBarActivity {
     private void OnSaveSuccess()
     {
         SaveAlertLevelToDevice();
+        setAlertButton();
     }
 
     private void OnSaveFail()
@@ -110,6 +111,7 @@ public class SettingsActivity extends ActionBarActivity {
     }
 
     private void UnSaveUiState() {
+        Log.i("AuroraWatch","UnSaveUiState called");
         alertLevel = lastAlertLevel;
         setAlertButton();
     }
@@ -217,7 +219,7 @@ public class SettingsActivity extends ActionBarActivity {
 
             if (registrationId.isEmpty()) {
                 gcmProgressDialog = ProgressDialog.show(activity,getResources().getString(R.string.pleasewait),"Registering with Google Cloud Services");
-                GcmRegistrationTask registrationTask = new GcmRegistrationTask(gcm, this, SENDER_ID, appVersion, appName);
+                final GcmRegistrationTask registrationTask = new GcmRegistrationTask(gcm, this, SENDER_ID, appVersion, appName);
                 registrationTask.setListener(new IAsyncFetchListener() {
                     public void onComplete(final String result) {
                         runOnUiThread(new Runnable() {
@@ -226,6 +228,7 @@ public class SettingsActivity extends ActionBarActivity {
                                     gcmProgressDialog.dismiss();
 
                                 if (result == "SUCCESS") {
+                                    registrationId = registrationTask.mRegistrationId;
                                     SaveAlertPreference((SettingsActivity)activity, accountName, SCOPE, alertLevel.name(), registrationId);
                                 } else {
                                     Toast.makeText(getApplicationContext(), "Registration with Google Cloud Services failed", Toast.LENGTH_SHORT).show();
@@ -273,7 +276,7 @@ public class SettingsActivity extends ActionBarActivity {
                 });
             }
         });
-        Log.i("AuroraWatch","Calling saveAlertPreferenceTask for " + accountName + ", alertLevel:" + alertLevel + ", regId:" + registrationId);
+        Log.i("AuroraWatch", "Calling saveAlertPreferenceTask for " + accountName + ", alertLevel:" + alertLevel + ", regId:" + registrationId);
         saveAlertPreferenceTask.execute();
     }
 

--- a/app/src/main/java/org/aurorawatchdevs/aurorawatch/activity/SettingsActivity.java
+++ b/app/src/main/java/org/aurorawatchdevs/aurorawatch/activity/SettingsActivity.java
@@ -88,22 +88,58 @@ public class SettingsActivity extends ActionBarActivity {
     }
 
     public void saveAlertLevel() {
-        try {
-            //Post alert setting to the cloud...
-            if (!SaveAlertSettingToCloud(alertLevel)) {
-                //if that failed, switch back
-                alertLevel = lastAlertLevel;
-            } else {
-                //Saving to the cloud worked, so save locally on the device too.
-                SharedPreferences settings = getSharedPreferences(appName, 0);
-                SharedPreferences.Editor editor = settings.edit();
-                editor.putInt("alertLevel", alertLevel.ordinal());
-                editor.apply();
-            }
-            setAlertButton();
-        } catch (Exception ex) {
-            Log.e(appName, "Saving prefs: " + ex.getMessage());
+        //Check we're online
+        if (!isDeviceOnline()) {
+            Toast.makeText(this, getResources().getString(R.string.not_online), Toast.LENGTH_SHORT).show();
+            UnSaveUiState();
         }
+
+        //Check / Prompt for account
+        if (checkUserAccount())
+            ContinueSavingAlertSettings(alertLevel);
+    }
+
+    private void OnSaveSuccess()
+    {
+        SaveAlertLevelToDevice();
+    }
+
+    private void OnSaveFail()
+    {
+        UnSaveUiState();
+    }
+
+    private void UnSaveUiState() {
+        alertLevel = lastAlertLevel;
+        setAlertButton();
+    }
+
+    private void SaveAlertLevelToDevice() {
+        SharedPreferences settings = getSharedPreferences(appName, 0);
+        SharedPreferences.Editor editor = settings.edit();
+        editor.putInt("alertLevel", alertLevel.ordinal());
+        editor.apply();
+    }
+
+    private boolean checkUserAccount() {
+        accountName = AccountUtils.getAccountName(this);
+        if (accountName == null) {
+            // Then the user was not found in the SharedPreferences. Either the
+            // application deliberately removed the account, or the application's
+            // data has been forcefully erased.
+            showAccountPicker();
+            return false;
+        }
+
+        Account account = AccountUtils.getGoogleAccountByName(this, accountName);
+        if (account == null) {
+            // Then the account has since been removed.
+            AccountUtils.removeAccount(this);
+            showAccountPicker();
+            return false;
+        }
+
+        return true;
     }
 
     @Override
@@ -173,16 +209,8 @@ public class SettingsActivity extends ActionBarActivity {
         }
     }
 
-    private boolean SaveAlertSettingToCloud(final AlertLevel alertLevel) {
-
-        if (!isDeviceOnline()) {
-            Toast.makeText(this, getResources().getString(R.string.not_online), Toast.LENGTH_SHORT).show();
-            return false;
-        }
-
-        if (!checkUserAccount())
-            return false;
-
+    private void ContinueSavingAlertSettings(final AlertLevel alertLevel)
+    {
         if (checkPlayServices()) {
             gcm = GoogleCloudMessaging.getInstance(this);
             registrationId = getRegistrationId(getApplicationContext());
@@ -200,8 +228,8 @@ public class SettingsActivity extends ActionBarActivity {
                                 if (result == "SUCCESS") {
                                     SaveAlertPreference((SettingsActivity)activity, accountName, SCOPE, alertLevel.name(), registrationId);
                                 } else {
-                                    UnSaveUiState();
                                     Toast.makeText(getApplicationContext(), "Registration with Google Cloud Services failed", Toast.LENGTH_SHORT).show();
+                                    OnSaveFail();
                                 }
                             }
                         });
@@ -212,9 +240,12 @@ public class SettingsActivity extends ActionBarActivity {
             else {
                 SaveAlertPreference(this, accountName, SCOPE, alertLevel.name(), registrationId);
             }
-            return true;
         }
-        return false;
+        else
+        {
+            OnSaveFail();
+        }
+
     }
 
     private void SaveAlertPreference(final SettingsActivity activity, String accountName, String scope, String alertLevel, String registrationId)
@@ -230,46 +261,20 @@ public class SettingsActivity extends ActionBarActivity {
                             gcmProgressDialog.dismiss();
 
                         if (result == "ERR") {
-                            UnSaveUiState();
                             Toast.makeText(getApplicationContext(), "Saving your alert preference failed", Toast.LENGTH_SHORT).show();
+                            OnSaveFail();
                         }
                         else
                         {
                             Toast.makeText(activity,"Alert preference was saved successfully",Toast.LENGTH_SHORT).show();
+                            OnSaveSuccess();
                         }
                     }
                 });
             }
         });
-
+        Log.i("AuroraWatch","Calling saveAlertPreferenceTask for " + accountName + ", alertLevel:" + alertLevel + ", regId:" + registrationId);
         saveAlertPreferenceTask.execute();
-    }
-
-    private void UnSaveUiState()
-    {
-        alertLevel = lastAlertLevel;
-        setAlertButton();
-    }
-
-    private boolean checkUserAccount() {
-        accountName = AccountUtils.getAccountName(this);
-        if (accountName == null) {
-            // Then the user was not found in the SharedPreferences. Either the
-            // application deliberately removed the account, or the application's
-            // data has been forcefully erased.
-            showAccountPicker();
-            return false;
-        }
-
-        Account account = AccountUtils.getGoogleAccountByName(this, accountName);
-        if (account == null) {
-            // Then the account has since been removed.
-            AccountUtils.removeAccount(this);
-            showAccountPicker();
-            return false;
-        }
-
-        return true;
     }
 
     private void showAccountPicker() {
@@ -289,10 +294,12 @@ public class SettingsActivity extends ActionBarActivity {
                     accountName = data.getStringExtra(
                             AccountManager.KEY_ACCOUNT_NAME);
                     AccountUtils.setAccountName(this, accountName);
-
+                    Log.i("AuroraWatch","AccountPicker returned OK for " + accountName);
+                    ContinueSavingAlertSettings(alertLevel);
                 } else if (resultCode == RESULT_CANCELED) {
                     Toast.makeText(this, "This application requires a Google account.",
                             Toast.LENGTH_SHORT).show();
+                    UnSaveUiState();
                     finish();
                 }
                 return;

--- a/app/src/main/java/org/aurorawatchdevs/aurorawatch/util/GcmRegistrationTask.java
+++ b/app/src/main/java/org/aurorawatchdevs/aurorawatch/util/GcmRegistrationTask.java
@@ -72,7 +72,7 @@ public class GcmRegistrationTask extends AsyncTask<Void, Void, String> {
 
     private void storeRegistrationId(String registrationId, int appVersion, String appName) {
         SharedPreferences settings = mContext.getSharedPreferences(appName, 0);
-        Log.i(appName, "Saving regId on app version " + appVersion);
+        Log.i(appName, "Saving regId on app version " + appVersion + " regid:" + registrationId);
         SharedPreferences.Editor editor = settings.edit();
         editor.putString(mPROPERTY_REG_ID, registrationId);
         editor.putInt(mPROPERTY_APP_VERSION, appVersion);

--- a/app/src/main/java/org/aurorawatchdevs/aurorawatch/util/SaveAlertPreferenceTask.java
+++ b/app/src/main/java/org/aurorawatchdevs/aurorawatch/util/SaveAlertPreferenceTask.java
@@ -65,12 +65,12 @@ public class SaveAlertPreferenceTask extends AsyncTask<Void,Void,String>  {
             String token = fetchToken();
             if (token != null) {
                 //try and post the setting...
-                Log.i(getClass().getSimpleName(), "Got AuroraWatch Token " + token);
+                Log.i("AuroraWatch", "Got AuroraWatch Token " + token);
                 List<NameValuePair> httpParameters = new ArrayList<NameValuePair>();
                 httpParameters.add(new BasicNameValuePair("token", token));
                 httpParameters.add(new BasicNameValuePair("level", ConvertedAlertLevel(mAlertLevel)));
                 httpParameters.add(new BasicNameValuePair("registrationId", mRegistrationId));
-                Log.i(getClass().getSimpleName(), "Making Post request for alert level " + ConvertedAlertLevel(mAlertLevel));
+                Log.i("AuroraWatch", "Making Post request for alert level " + ConvertedAlertLevel(mAlertLevel));
                 String success = HttpUtil.postRequest("https://aurora-watch-uk.appspot.com/saveAlertLevel", httpParameters);
                 if (success.equals("ERR")) {
                     mActivity.handleException(new Exception("Token validation failed"));
@@ -78,12 +78,12 @@ public class SaveAlertPreferenceTask extends AsyncTask<Void,Void,String>  {
                 }
             }
         } catch (IOException e) {
-            Log.e(getClass().getSimpleName(), "IO Error in SaveAlertPreferenceTask... ");
+            Log.e("AuroraWatch", "IO Error in SaveAlertPreferenceTask... ");
             e.printStackTrace();
             return "ERR";
         }
         catch (Exception e) {
-            Log.e(getClass().getSimpleName(), "Error in SaveAlertPreferenceTask... ");
+            Log.e("AuroraWatch", "Error in SaveAlertPreferenceTask... ");
             e.printStackTrace();
             return "ERR";
         }
@@ -105,6 +105,7 @@ public class SaveAlertPreferenceTask extends AsyncTask<Void,Void,String>  {
      */
     protected String fetchToken() throws IOException {
         try {
+            Log.i("AuroraWatch","Calling fetchToken...");
             return GoogleAuthUtil.getToken(mActivity, mEmail, mScope);
         } catch (UserRecoverableAuthException userRecoverableException) {
             mActivity.handleException(userRecoverableException);

--- a/app/src/main/java/org/aurorawatchdevs/aurorawatch/util/SaveAlertPreferenceTask.java
+++ b/app/src/main/java/org/aurorawatchdevs/aurorawatch/util/SaveAlertPreferenceTask.java
@@ -76,6 +76,13 @@ public class SaveAlertPreferenceTask extends AsyncTask<Void,Void,String>  {
                     mActivity.handleException(new Exception("Token validation failed"));
                     return "ERR";
                 }
+                else
+                return "OK";
+            }
+            else
+            {
+                Log.e("AuroraWatch","fetchToken() failed in SaveAlertPreferenceTask");
+                return "ERR";
             }
         } catch (IOException e) {
             Log.e("AuroraWatch", "IO Error in SaveAlertPreferenceTask... ");
@@ -87,8 +94,6 @@ public class SaveAlertPreferenceTask extends AsyncTask<Void,Void,String>  {
             e.printStackTrace();
             return "ERR";
         }
-
-        return "OK";
     }
 
     @Override


### PR DESCRIPTION
With the latest changes this seems to work for me now (tested on both phone and tablet using a release-key build).

Probably could do with a sanity check- basically there were two problems with the original code:
- CheckUserAccount would return false right when displaying the google account picker, because everything is async, therefore the reg process didn't know to restart. Fixed that by continuing the process when the account picker returns.
- The RegistrationTaskListener didn't update it's registrationID value when the task returned success, so although it carried on trying to register, it didn't pass an ID so it failed.

The code as it is now is adding registered devices to the datastore - see https://console.developers.google.com/project/aurora-watch-uk/datastore/query?queryType=KindQuery&namespace=&kind=AlertClient

Interestingly, if I load the test-alert URL I'm only seeing it pop up on my phone. I'll check the server logs and ensure it's sending to both registered ID's for a given email address.
